### PR TITLE
fix: Symfony 3.0 compatilility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7
@@ -11,11 +10,6 @@ env:
    - SYMFONY_VERSION=2.7.*
    - SYMFONY_VERSION=2.8.*
    - SYMFONY_VERSION=3.0.*
-
-matrix:
-  exclude:
-    - php: 5.4
-      env: SYMFONY_VERSION=3.0.*
       
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ php:
   - 7
 
 env:
-   - SYMFONY_VERSION=2.3.*
-   - SYMFONY_VERSION=2.7.*
-   - SYMFONY_VERSION=2.8.*
-   - SYMFONY_VERSION=3.0.*
+  - SYMFONY_VERSION=2.3.*
+  - SYMFONY_VERSION=2.7.*
+  - SYMFONY_VERSION=2.8.*
+  - SYMFONY_VERSION=3.0.*
       
 branches:
   only:
@@ -17,11 +17,8 @@ branches:
 
 before_script:
   - wget http://getcomposer.org/composer.phar
-  - php composer.phar require symfony/dependency-injection:${SYMFONY_VERSION} --no-update --dev
-  - php composer.phar require symfony/event-dispatcher:${SYMFONY_VERSION} --no-update --dev
-  - php composer.phar require symfony/config:${SYMFONY_VERSION} --no-update --dev
-  - php composer.phar require symfony/yaml:${SYMFONY_VERSION} --no-update --dev
-  - php composer.phar update --dev
+  - php composer.phar require symfony/dependency-injection:${SYMFONY_VERSION} --no-update
+  - php composer.phar install
 
 script:
   - vendor/bin/coke

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,28 @@ php:
   - 5.6
   - 7
 
+env:
+   - SYMFONY_VERSION=2.3.*
+   - SYMFONY_VERSION=2.7.*
+   - SYMFONY_VERSION=2.8.*
+   - SYMFONY_VERSION=3.0.*
+
+matrix:
+  exclude:
+    - php: 5.4
+      env: SYMFONY_VERSION=3.0.*
+      
 branches:
   only:
     - master
 
 before_script:
   - wget http://getcomposer.org/composer.phar
-  - php composer.phar install --dev
+  - php composer.phar require symfony/dependency-injection:${SYMFONY_VERSION} --no-update --dev
+  - php composer.phar require symfony/event-dispatcher:${SYMFONY_VERSION} --no-update --dev
+  - php composer.phar require symfony/config:${SYMFONY_VERSION} --no-update --dev
+  - php composer.phar require symfony/yaml:${SYMFONY_VERSION} --no-update --dev
+  - php composer.phar update --dev
 
 script:
   - vendor/bin/coke

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5",
         "elasticsearch/elasticsearch": "~2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,15 @@
         "elasticsearch/elasticsearch": "~2.0"
     },
     "require-dev": {
-        "atoum/atoum":                      "master-dev",
+        "atoum/atoum":                      "^2.6",
         "m6web/coke":                       "~1.2.0",
         "m6web/symfony2-coding-standard":   "~1.2.0",
-        "symfony/dependency-injection":     "~2.3.0",
-        "symfony/event-dispatcher":         "~2.3.0",
-        "symfony/config":                   "~2.3.0",
-        "symfony/yaml":                     "~2.3"
+        "symfony/dependency-injection":     "^2.3|^3.0",
+        "symfony/event-dispatcher":         "^2.3|^3.0",
+        "symfony/config":                   "^2.3|^3.0",
+        "symfony/yaml":                     "^2.3|^3.0"
     },
     "autoload": {
         "psr-0": { "": "src/" }
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
In Symfony 3.0 Dependency Injection component, setFactoryClass and setFactoryMethod
doesn't exists anymore.
It adds a `method_exists` tweak :/ to keep the Symfony 2.3 backward compatibility.
It also set up travis to check Symfony LTS versions.