### PR TITLE
Symfony 3.0 compatibility on 0.3 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
+sudo: false
+
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7
+
+env:
+  - SYMFONY_VERSION=2.3.*
+  - SYMFONY_VERSION=2.7.*
+  - SYMFONY_VERSION=2.8.*
+  - SYMFONY_VERSION=3.0.*
 
 branches:
   only:
     - master
 
 before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar install --dev
+  - composer install
 
 script:
   - vendor/bin/coke

--- a/composer.json
+++ b/composer.json
@@ -10,19 +10,18 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
-        "elasticsearch/elasticsearch": "~1.3.2"
+        "php": ">=5.5",
+        "elasticsearch/elasticsearch": "^1.4.0"
     },
     "require-dev": {
-        "atoum/atoum":                      "master-dev",
+        "atoum/atoum":                      "^2.6",
         "m6web/coke":                       "~1.2.0",
         "m6web/symfony2-coding-standard":   "~1.2.0",
-        "symfony/dependency-injection":     "~2.3.0",
-        "symfony/config":                   "~2.3.0",
-        "symfony/yaml":                     "~2.3"
+        "symfony/dependency-injection":     "^2.3|^3.0",
+        "symfony/config":                   "^2.3|^3.0",
+        "symfony/yaml":                     "^2.3|^3.0"
     },
     "autoload": {
         "psr-0": { "": "src/" }
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/src/M6Web/Bundle/ElasticsearchBundle/Resources/config/services.yml
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Resources/config/services.yml
@@ -4,11 +4,11 @@ parameters:
 
 services:
     m6web_elasticsearch.data_collector:
-        class: %m6web_elasticsearch.data_collector.class%
+        class: '%m6web_elasticsearch.data_collector.class%'
         tags:
             - { name: data_collector, template: "M6WebElasticsearchBundle:Collector:elasticsearch", id: elasticsearch }
         arguments:
-            - @m6web_elasticsearch.logger
+            - '@m6web_elasticsearch.logger'
 
     m6web_elasticsearch.logger:
-        class: %m6web_elasticsearch.logger.class%
+        class: '%m6web_elasticsearch.logger.class%'


### PR DESCRIPTION
0.x branch works with Elasticsearch 1.x

This fixes YAML deprecation alerts.