### PR TITLE
Add new selector and connection pool.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ branches:
     - master
 
 before_script:
+  # disable xdebug
+  - phpenv config-rm xdebug.ini
   - wget http://getcomposer.org/composer.phar
   - php composer.phar require symfony/dependency-injection:${SYMFONY_VERSION} --no-update
   - php composer.phar install

--- a/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/Configuration.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/Configuration.php
@@ -33,6 +33,8 @@ class Configuration implements ConfigurationInterface
                             ->performNoDeepMerging()
                             ->prototype('scalar')->end()
                         ->end()
+                        ->scalarNode('connectionPoolClass')->end()
+                        ->scalarNode('selectorClass')->end()
                         ->integerNode('retries')->end()
                         ->scalarNode('logger')->end()
                         ->variableNode('headers')->end()

--- a/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/M6WebElasticsearchExtension.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/M6WebElasticsearchExtension.php
@@ -62,21 +62,29 @@ class M6WebElasticsearchExtension extends Extension
 
         $handlerId = $this->createHandler($container, $config, $definitionId);
 
-        $builderConfig = [
+        $clientConfig = [
             'hosts'   => $config['hosts'],
             'handler' => new Reference($handlerId),
         ];
 
         if (isset($config['retries'])) {
-            $builderConfig['retries'] = $config['retries'];
+            $clientConfig['retries'] = $config['retries'];
         }
 
         if (isset($config['logger'])) {
-            $builderConfig['logger'] = new Reference($config['logger']);
+            $clientConfig['logger'] = new Reference($config['logger']);
+        }
+
+        if (!empty($config['connectionPoolClass'])) {
+            $clientConfig['connectionPool'] = $config['connectionPoolClass'];
+        }
+
+        if (!empty($config['selectorClass'])) {
+            $clientConfig['selector'] = $config['selectorClass'];
         }
 
         $definition = (new Definition('Elasticsearch\Client'))
-            ->setArguments([$builderConfig]);
+            ->setArguments([$clientConfig]);
         $this->setFactoryToDefinition('Elasticsearch\ClientBuilder', 'fromConfig', $definition);
 
         $container->setDefinition($definitionId, $definition);
@@ -129,22 +137,21 @@ class M6WebElasticsearchExtension extends Extension
     }
 
     /**
-     * @param string     $classname
+     * @param string     $className
      * @param string     $method
      * @param Definition $definition
      */
-    private function setFactoryToDefinition($classname, $method, Definition $definition)
+    private function setFactoryToDefinition($className, $method, Definition $definition)
     {
         // Symfony 2.3 backward compatibility
         if (method_exists('Symfony\Component\DependencyInjection\Definition', 'setFactory')) {
-            $definition->setFactory([$classname, $method]);
+            $definition->setFactory([$className, $method]);
         } else {
             $definition
-                ->setFactoryClass($classname)
+                ->setFactoryClass($className)
                 ->setFactoryMethod($method);
         }
     }
-
 
     /**
      * @param ContainerBuilder $container

--- a/src/M6Web/Bundle/ElasticsearchBundle/Elasticsearch/ConnectionPool/Selector/RandomStickySelector.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Elasticsearch/ConnectionPool/Selector/RandomStickySelector.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace M6Web\Bundle\ElasticsearchBundle\Elasticsearch\ConnectionPool\Selector;
+
+use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
+use Elasticsearch\ConnectionPool\Selectors\SelectorInterface;
+use Elasticsearch\Connections\ConnectionInterface;
+
+/**
+ * Class RandomStickySelector
+ *
+ * @package M6Web\Bundle\ElasticsearchBundle\Elasticsearch\ConnectionPool\Selector
+ */
+class RandomStickySelector implements SelectorInterface
+{
+    protected $current;
+
+    /**
+     * Select a random connection from the provided array and stick with it.
+     *
+     * @param ConnectionInterface[] $connections Array of Connection objects
+     *
+     * @throws NoNodesAvailableException
+     *
+     * @return ConnectionInterface
+     */
+    public function select($connections)
+    {
+        if (empty($connections)) {
+            throw new NoNodesAvailableException('No node to select from…');
+        }
+
+        if (($this->current === null) || !isset($connections[$this->current])) {
+            $this->current = array_rand($connections);
+        }
+
+        return $connections[$this->current];
+    }
+}

--- a/src/M6Web/Bundle/ElasticsearchBundle/Elasticsearch/ConnectionPool/StaticAliveNoPingConnectionPool.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Elasticsearch/ConnectionPool/StaticAliveNoPingConnectionPool.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace M6Web\Bundle\ElasticsearchBundle\Elasticsearch\ConnectionPool;
+
+use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
+use Elasticsearch\ConnectionPool\StaticNoPingConnectionPool;
+use Elasticsearch\Connections\Connection;
+
+/**
+ * Class StaticAliveNoPingConnectionPool
+ *
+ * > Extend StaticNoPingConnectionPool and add the ability to remove any failed connection
+ *    from the list of eligible connections to be chosen from by the selector.
+ *
+ * @package M6Web\Bundle\ElasticsearchBundle\Elasticsearch\ConnectionPool
+ */
+class StaticAliveNoPingConnectionPool extends StaticNoPingConnectionPool
+{
+    /**
+     * @var int
+     */
+    private $pingTimeout    = 60;
+
+    /**
+     * @var int
+     */
+    private $maxPingTimeout = 3600;
+
+    /**
+     * > Allow to customize the ping time out.
+     *
+     * @param int $pingTimeout
+     */
+    public function setPingTimeout($pingTimeout)
+    {
+        $this->pingTimeout = $pingTimeout;
+    }
+
+    /**
+     * > Allow to customize the ping max time out.
+     *
+     * @param int $maxPingTimeout
+     */
+    public function setMaxPingTimeout($maxPingTimeout)
+    {
+        $this->maxPingTimeout = $maxPingTimeout;
+    }
+
+    /**
+     * @param bool $force
+     *
+     * @return Connection
+     * @throws \Elasticsearch\Common\Exceptions\NoNodesAvailableException
+     */
+    public function nextConnection($force = false)
+    {
+        // > Replace $this->connections by $connections in order to modify the list later.
+        $connections = $this->connections;
+        $total = count($connections);
+        while ($total--) {
+            /** @var Connection $connection */
+            $connection = $this->selector->select($connections);
+            if ($connection->isAlive() === true) {
+                return $connection;
+            }
+
+            if ($this->readyToRevive($connection) === true) {
+                return $connection;
+            }
+
+            // > Remove the failed connection from the list of eligible connections.
+            $connections = array_filter(
+                $connections,
+                function ($baseConnection) use ($connection) {
+                    return $baseConnection !== $connection;
+                }
+            );
+        }
+
+        throw new NoNodesAvailableException("No alive nodes found in your cluster");
+    }
+
+    /**
+     * > Same as parent private method.
+     *
+     * @param Connection $connection
+     *
+     * @return bool
+     */
+    protected function readyToRevive(Connection $connection)
+    {
+        $timeout = min(
+            $this->pingTimeout * pow(2, $connection->getPingFailures()),
+            $this->maxPingTimeout
+        );
+
+        if ($connection->getLastPing() + $timeout < time()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Elasticsearch/ConnectionMocker.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Elasticsearch/ConnectionMocker.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace M6Web\Bundle\ElasticsearchBundle\Tests\Units\Elasticsearch;
+
+use Elasticsearch\Connections\Connection;
+
+/**
+ * Class ConnectionMocker
+ *
+ * @package M6Web\Bundle\ElasticsearchBundle\Tests\Units\Elasticsearch
+ */
+trait ConnectionMocker
+{
+    /**
+     * @param int $numberOfConnections
+     *
+     * @return Connection[]
+     */
+    protected function getConnectionMocks($numberOfConnections = 1)
+    {
+        return array_map([$this, 'getConnectionMock'], array_fill(0, $numberOfConnections, []));
+    }
+
+    /**
+     * @param array $callbacks
+     *
+     * @return Connection
+     */
+    protected function getConnectionMock(array $callbacks = [])
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+
+        $connectionMock = new \mock\Elasticsearch\Connections\Connection;
+
+        foreach ($callbacks as $method => $callback) {
+            $this->calling($connectionMock)->$method = $callback;
+        }
+
+        return $connectionMock;
+    }
+}

--- a/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Elasticsearch/ConnectionPool/Selector/RandomStickySelector.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Elasticsearch/ConnectionPool/Selector/RandomStickySelector.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace M6Web\Bundle\ElasticsearchBundle\Tests\Units\Elasticsearch\ConnectionPool\Selector;
+
+use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
+use Elasticsearch\Connections\Connection;
+use M6Web\Bundle\ElasticsearchBundle\Tests\Units\Elasticsearch\ConnectionMocker;
+use mageekguy\atoum\test;
+
+/**
+ * Class RandomStickySelector
+ *
+ * @package M6Web\Bundle\ElasticsearchBundle\Tests\Units\Elasticsearch\ConnectionPool\Selector
+ */
+class RandomStickySelector extends test
+{
+    use ConnectionMocker;
+
+    /**
+     * Test the behavior of the select method if no connections are given.
+     */
+    public function testSelectFromEmpty()
+    {
+        $this
+            ->if($this->newTestedInstance)
+
+            ->then
+                ->exception(
+                    function () {
+                        $this->testedInstance->select([]);
+                    }
+                )
+                    ->isInstanceOf(NoNodesAvailableException::class);
+    }
+
+    /**
+     * Test the stickiness of the select method.
+     *
+     * @return void
+     */
+    public function testSelectSticky()
+    {
+        $this
+            ->given($connections = $this->getConnectionMocks(1000))
+            ->if($this->newTestedInstance)
+
+            // Test returned class is a connection.
+            ->then
+                ->object($firstConnectionReturned = $this->testedInstance->select($connections))
+                    ->isInstanceOf(Connection::class)
+
+            // Every next select should be identical to the first.
+            ->and
+                ->object($newSelect = $this->testedInstance->select($connections))
+                    ->isIdenticalTo($firstConnectionReturned)
+            ->and
+                ->object($newSelect = $this->testedInstance->select($connections))
+                    ->isIdenticalTo($firstConnectionReturned)
+            ->and
+                ->object($newSelect = $this->testedInstance->select($connections))
+                    ->isIdenticalTo($firstConnectionReturned)
+            ->and
+                ->object($newSelect = $this->testedInstance->select($connections))
+                    ->isIdenticalTo($firstConnectionReturned)
+            ->and
+                ->object($newSelect = $this->testedInstance->select($connections))
+                    ->isIdenticalTo($firstConnectionReturned)
+
+            // First connection returned is excluded from the available connections.
+            ->if($connections =
+                array_filter(
+                    $connections,
+                    function ($baseConnection) use ($firstConnectionReturned) {
+                        return $baseConnection !== $firstConnectionReturned;
+                    }
+                )
+            )
+            // Next connection returned is a new one and every call after should be the same.
+            ->then
+                ->object($newConnectionReturned = $this->testedInstance->select($connections))
+                    ->isInstanceOf(Connection::class)
+                    ->isNotIdenticalTo($firstConnectionReturned)
+            ->and
+                ->object($newSelect = $this->testedInstance->select($connections))
+                    ->isIdenticalTo($newConnectionReturned)
+            ->and
+                ->object($newSelect = $this->testedInstance->select($connections))
+                    ->isIdenticalTo($newConnectionReturned)
+            ->and
+                ->object($newSelect = $this->testedInstance->select($connections))
+                    ->isIdenticalTo($newConnectionReturned)
+            ->and
+                ->object($newSelect = $this->testedInstance->select($connections))
+                    ->isIdenticalTo($newConnectionReturned)
+            ->and
+                ->object($newSelect = $this->testedInstance->select($connections))
+                    ->isIdenticalTo($newConnectionReturned);
+    }
+}

--- a/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Elasticsearch/ConnectionPool/StaticAliveNoPingConnectionPool.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Elasticsearch/ConnectionPool/StaticAliveNoPingConnectionPool.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace M6Web\Bundle\ElasticsearchBundle\Tests\Units\Elasticsearch\ConnectionPool;
+
+use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
+use Elasticsearch\ConnectionPool\Selectors\SelectorInterface;
+use Elasticsearch\Connections\Connection;
+use Elasticsearch\Connections\ConnectionFactoryInterface;
+use M6Web\Bundle\ElasticsearchBundle\Tests\Units\Elasticsearch\ConnectionMocker;
+use mageekguy\atoum\test;
+
+/**
+ * Class StaticAliveNoPingConnectionPool
+ *
+ * @package M6Web\Bundle\ElasticsearchBundle\Tests\Units\Elasticsearch\ConnectionPool
+ */
+class StaticAliveNoPingConnectionPool extends test
+{
+    use ConnectionMocker;
+
+    /**
+     * Test Select
+     */
+    public function testNextConnectionAllOk()
+    {
+        $this
+            ->given($connections = [$first = $this->getConnectionMockReady(), $second = $this->getConnectionMockReady()])
+            ->if($this->newTestedInstance($connections, $this->getSelectorMock(), $this->getConnectionFactoryMock(), []))
+
+            // Test returned class is a connection.
+            ->then
+                ->object($firstConnectionReturned = $this->testedInstance->nextConnection($connections))
+                    ->isIdenticalTo($first);
+    }
+
+    /**
+     * Test Select
+     */
+    public function testNextConnectionOneFailure()
+    {
+        $this
+            ->given($connections = [$first = $this->getConnectionMockFailed(), $second = $this->getConnectionMockReady()])
+            ->if($this->newTestedInstance($connections, $this->getSelectorMock(), $this->getConnectionFactoryMock(), []))
+
+            // Test returned class is a connection.
+            ->then
+                ->object($firstConnectionReturned = $this->testedInstance->nextConnection($connections))
+                    ->isIdenticalTo($second);
+    }
+
+    /**
+     * Test Select
+     */
+    public function testNextConnectionFullFailure()
+    {
+        $this
+            ->given($connections = [$first = $this->getConnectionMockFailed(), $second = $this->getConnectionMockFailed()])
+            ->if($this->newTestedInstance($connections, $this->getSelectorMock(), $this->getConnectionFactoryMock(), []))
+
+            // Test returned class is a connection.
+            ->then
+                ->exception(
+                    function () use ($connections) {
+                        $this->testedInstance->nextConnection($connections);
+                    }
+                )
+                    ->isInstanceOf(NoNodesAvailableException::class);
+    }
+
+    /**
+     * @return Connection
+     */
+    protected function getConnectionMockReady()
+    {
+        return $this->getConnectionMock(
+            [
+                'isAlive' => true,
+                'getPingFailures' => 0,
+                'getLastPing' => 0,
+            ]
+        );
+    }
+
+    /**
+     * @return Connection
+     */
+    protected function getConnectionMockFailed()
+    {
+        return $this->getConnectionMock(
+            [
+                'isAlive' => false,
+                'getPingFailures' => time(),
+                'getLastPing' => time(),
+            ]
+        );
+    }
+
+    /**
+     * @return SelectorInterface
+     */
+    protected function getSelectorMock()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+
+        $selectorMock = new \mock\Elasticsearch\ConnectionPool\Selectors\SelectorInterface;
+
+        $this->calling($selectorMock)->select = function ($connections) {
+            return reset($connections);
+        };
+
+        return $selectorMock;
+    }
+
+    /**
+     * @return ConnectionFactoryInterface
+     */
+    protected function getConnectionFactoryMock()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+
+        $selectorMock = new \mock\Elasticsearch\Connections\ConnectionFactoryInterface;
+
+        return $selectorMock;
+    }
+}


### PR DESCRIPTION
# Why
## Random Sticky Selector
When using many concurrent scripts with many connections, we want to pick one randomly, and stick with it for the whole execution.
## Static Alive No Ping Connection Pool
When using many connection, if one failed to connect, we don't want to retry it.

# How
Added the new Selector and the new ConnectionPool.
Added unit test. Didn't test the whole random thing :/
