### PR TITLE
Add option to customize client class.

### DIFF
--- a/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/Configuration.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/Configuration.php
@@ -33,6 +33,7 @@ class Configuration implements ConfigurationInterface
                             ->performNoDeepMerging()
                             ->prototype('scalar')->end()
                         ->end()
+                        ->scalarNode('client_class')->defaultValue('Elasticsearch\Client')->end()
                         ->scalarNode('connectionPoolClass')->end()
                         ->scalarNode('selectorClass')->end()
                         ->integerNode('retries')->end()

--- a/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/M6WebElasticsearchExtension.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/M6WebElasticsearchExtension.php
@@ -83,7 +83,7 @@ class M6WebElasticsearchExtension extends Extension
             $clientConfig['selector'] = $config['selectorClass'];
         }
 
-        $definition = (new Definition('Elasticsearch\Client'))
+        $definition = (new Definition($config['client_class']))
             ->setArguments([$clientConfig]);
         $this->setFactoryToDefinition('Elasticsearch\ClientBuilder', 'fromConfig', $definition);
 


### PR DESCRIPTION
# Why
In order to use the https://github.com/M6Web/ElasticsearchMock, we have to customize the client class.

# How
Add a new option for clients to specify a client class. Default value is traditionnal `Elasticsearch\Client`.