### PR TITLE
Update to newer atoum versions

### DIFF
--- a/.bootstrap.atoum.php
+++ b/.bootstrap.atoum.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once __DIR__ . '/vendor/autoload.php';

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 
 php:
-  - 7
+  - 7.0
+  - 7.1
 
 env:
   - SYMFONY_VERSION=2.3.*

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "elasticsearch/elasticsearch": "^5.1.0"
     },
     "require-dev": {
-        "atoum/atoum":                      "^2.6",
+        "atoum/atoum":                      "^2.8|^3.0",
         "m6web/coke":                       "~1.2.0",
         "m6web/symfony2-coding-standard":   "~1.2.0",
         "symfony/dependency-injection":     "^2.3|^3.0",


### PR DESCRIPTION
atoum 2.8 allows us to remove the bootstrap when it's only used to
require the autoloader (see atoum/atoum#605)

atoum 3.0 allows us to run tests on latest PHP versions.