### PR TITLE
Duration is received as seconds but stored as ms.

### DIFF
--- a/src/M6Web/Bundle/ElasticsearchBundle/Handler/EventHandler.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Handler/EventHandler.php
@@ -59,7 +59,7 @@ class EventHandler
                 ->setUri($request['uri'])
                 ->setMethod($request['http_method'])
                 ->setStatusCode($response['status'])
-                ->setDuration($response['transfer_stats']['total_time'])
+                ->setDuration($response['transfer_stats']['total_time'] * 1000)
                 ->setTook($getTook($response));
 
             if (isset($request['body'])) {

--- a/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Handler/EventHandler.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Handler/EventHandler.php
@@ -65,7 +65,7 @@ class EventHandler extends atoum
             [
                 'request'       => ['uri' => '/_search', 'http_method' => 'GET'],
                 'response'      => [
-                    'transfer_stats' => ['total_time' => 500],
+                    'transfer_stats' => ['total_time' => 0.5],
                     'status'         => 200,
                     'body'           => fopen('data://text/plain,', 'r'),
                 ],
@@ -79,7 +79,7 @@ class EventHandler extends atoum
             [
                 'request'       => ['uri' => '/_count', 'http_method' => 'POST'],
                 'response'      => [
-                    'transfer_stats' => ['total_time' => 1000],
+                    'transfer_stats' => ['total_time' => 1],
                     'status'         => 500,
                     'body'           => fopen('data://text/plain,'.json_encode(['took' => 10]), 'r'),
                 ],


### PR DESCRIPTION
Change setted duration as ms instead of seconds in Elastic Event Handler.