### PR TITLE
varToString > cloneVar

### DIFF
--- a/src/M6Web/Bundle/ElasticsearchBundle/DataCollector/ElasticsearchDataCollector.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/DataCollector/ElasticsearchDataCollector.php
@@ -32,7 +32,7 @@ class ElasticsearchDataCollector extends DataCollector
         $query = array(
             'method'      => $event->getMethod(),
             'uri'         => $event->getUri(),
-            'headers'     => $this->varToString($event->getHeaders()),
+            'headers'     => $this->cloneVar($event->getHeaders()),
             'status_code' => $event->getStatusCode(),
             'duration'    => $event->getDuration(),
             'took'        => $event->getTook(),


### PR DESCRIPTION
deprecation fix from:

Symfony\Component\HttpKernel\DataCollector\DataCollector

https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php#L96

going to break with 4.0