### PR TITLE
Add missing reset method in datacollector

### DIFF
--- a/src/M6Web/Bundle/ElasticsearchBundle/DataCollector/ElasticsearchDataCollector.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/DataCollector/ElasticsearchDataCollector.php
@@ -17,10 +17,7 @@ class ElasticsearchDataCollector extends DataCollector
      */
     public function __construct()
     {
-        $this->data = [
-            'queries'              => [],
-            'total_execution_time' => 0,
-        ];
+        $this->reset();
     }
 
 
@@ -76,6 +73,17 @@ class ElasticsearchDataCollector extends DataCollector
     public function getTotalExecutionTime()
     {
         return $this->data['total_execution_time'];
+    }
+
+    /**
+     * Resets this data collector to its initial state.
+     */
+    public function reset()
+    {
+        $this->data = [
+            'queries'              => [],
+            'total_execution_time' => 0,
+        ];
     }
 
 }


### PR DESCRIPTION
Now, the `reset` method is  required by the interface `DataCollector` of symfony 4`