### PR TITLE
composer.json: Support version ^6.0.0 for elasticsearch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "elasticsearch/elasticsearch": "^5.1.0"
+        "elasticsearch/elasticsearch": "^5.1.0 || ^6.0.0"
     },
     "require-dev": {
         "atoum/atoum":                      "^2.8|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
     ],
     "require": {
         "php": ">=7.0",
-        "elasticsearch/elasticsearch": "^5.1.0 || ^6.0.0"
+        "elasticsearch/elasticsearch": "^5.1.0||^6.0.0"
     },
     "require-dev": {
-        "atoum/atoum":                      "^2.8|^3.0",
+        "atoum/atoum":                      "^2.8||^3.0",
         "m6web/coke":                       "~1.2.0",
         "m6web/symfony2-coding-standard":   "~1.2.0",
-        "symfony/dependency-injection":     "^2.3|^3.0",
-        "symfony/event-dispatcher":         "^2.3|^3.0",
-        "symfony/config":                   "^2.3|^3.0",
-        "symfony/yaml":                     "^2.3|^3.0"
+        "symfony/dependency-injection":     "^2.3||^3.0",
+        "symfony/event-dispatcher":         "^2.3||^3.0",
+        "symfony/config":                   "^2.3||^3.0",
+        "symfony/yaml":                     "^2.3||^3.0"
     },
     "autoload": {
         "psr-0": { "": "src/" }


### PR DESCRIPTION
Allow use of the bundle for ElasticSearch/ElasticSearch 6.0.0 and higher

There don't seem to be any backwards incompatibilities, so not permitting limits people unnecessarily.