### PR TITLE
feat(header): Allow to add specific Host header

### DIFF
--- a/src/M6Web/Bundle/ElasticsearchBundle/Handler/HeadersHandler.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Handler/HeadersHandler.php
@@ -2,6 +2,7 @@
 
 namespace M6Web\Bundle\ElasticsearchBundle\Handler;
 
+use GuzzleHttp\Ring\Core;
 use GuzzleHttp\Ring\Future\FutureInterface;
 
 /**
@@ -57,6 +58,10 @@ class HeadersHandler
      */
     public function __invoke(array $request)
     {
+        // By default, host is stored in headers and final url is forged later.
+        // We need to build url now to handle the case when we want to add a custom Host header.
+        $request['url'] = Core::url($request);
+
         $handler = $this->handler;
         foreach ($this->headers as $key => $value) {
             if ($key == 'Accept-Encoding' && in_array('gzip', $value)) {

--- a/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Handler/HeadersHandler.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Handler/HeadersHandler.php
@@ -55,25 +55,26 @@ class HeadersHandler extends atoum
     {
         return [
             [
-                'request'         => [],
-                'expectedRequest' => [],
+                'request'         => ['headers' => ['host' => ['localhost:9200']]],
+                'expectedRequest' => ['headers' => ['host' => ['localhost:9200']], 'url' => 'http://localhost:9200'],
                 'headers'         => [],
             ],
             [
                 'request'         => ['headers' => ['host' => ['localhost:9200']]],
-                'expectedRequest' => ['headers' => ['host' => ['localhost:9200']]],
-                'headers'         => [],
-            ],
-            [
-                'request'         => ['headers' => ['host' => ['localhost:9200']]],
-                'expectedRequest' => ['headers' => ['host' => ['localhost:9200'], 'X-AddMe' => ['Hello']]],
+                'expectedRequest' => ['headers' => ['host' => ['localhost:9200'], 'X-AddMe' => ['Hello']], 'url' => 'http://localhost:9200'],
                 'headers'         => ['X-AddMe' => ['Hello']],
+            ],
+            [
+                'request'         => ['headers' => ['host' => ['localhost:9200']]],
+                'expectedRequest' => ['headers' => ['host' => ['other-host.com']], 'url' => 'http://localhost:9200'],
+                'headers'         => ['host' => ['other-host.com']],
             ],
             [
                 'request'         => ['headers' => ['host' => ['localhost:9200']]],
                 'expectedRequest' => [
                     'headers' => ['host' => ['localhost:9200'], 'Accept-Encoding' => ['gzip']],
                     'client'  => ['decode_content' => true],
+                    'url' => 'http://localhost:9200'
                 ],
                 'headers'         => ['Accept-Encoding' => ['gzip']],
             ],
@@ -81,6 +82,7 @@ class HeadersHandler extends atoum
                 'request'         => ['headers' => ['host' => ['localhost:9200']]],
                 'expectedRequest' => [
                     'headers' => ['host' => ['localhost:9200'], 'Accept-Encoding' => ['deflate']],
+                    'url' => 'http://localhost:9200'
                 ],
                 'headers'         => ['Accept-Encoding' => ['deflate']],
             ],


### PR DESCRIPTION
For optimization purpose, we intend to use a _proxy_ between Php and ES in order to maintain persistent http connections opened. To do this in a common way, the http request must be addressed to the proxy, but using an `Host` header indicating the actual ES server to reach.

Unfortunately, `Host` header is not handled correctly, since the ES client already split the input url into scheme, uri… and a `host` header. Then, when we try to _add_ our own `host` header, previous one is dropped 😕 

The final url is computed in the [`CurlFactory` of guzzle/RingPhp (deprecatde)](https://github.com/guzzle/RingPHP/blob/5e2a174052995663dd68e6b5ad838afd47dd615b/src/Client/CurlFactory.php#L159), using [`Core::url` function](https://github.com/guzzle/RingPHP/blob/5e2a174052995663dd68e6b5ad838afd47dd615b/src/Core.php#L192), but if an `url` field already exist, the client use it.

The idea here is to compute the final url **before** to modify headers, in order to keep original host in the url.
Since `url` field is always computed, tests must be updated to take this new parameter into account.