### PR TITLE
fix!: reenforce type usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,17 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "elasticsearch/elasticsearch": "^5.1.0||^6.0.0||^7.0"
+        "elasticsearch/elasticsearch": "^5.1.0||^6.0.0||^7.0",
+        "symfony/event-dispatcher": "^4.4||^5.0||^6.0",
+        "symfony/yaml": "^4.4||^5.0||^6.0",
+        "symfony/http-foundation": "^4.4||^5.0||^6.0",
+        "symfony/config": "^4.4||^5.0||^6.0",
+        "symfony/http-kernel": "^4.4||^5.0||^6.0",
+        "symfony/dependency-injection": "^4.4||^5.0||^6.0"
     },
     "require-dev": {
-        "atoum/atoum":                      "^4.0",
-        "m6web/php-cs-fixer-config":        "^2.0",
-        "symfony/dependency-injection":     "^4.4||^5.0||^6.0",
-        "symfony/event-dispatcher":         "^4.4||^5.0||^6.0",
-        "symfony/config":                   "^4.4||^5.0||^6.0",
-        "symfony/yaml":                     "^4.4||^5.0||^6.0",
-        "symfony/http-foundation":          "^4.4||^5.0||^6.0",
-        "symfony/http-kernel":              "^4.4||^5.0||^6.0"
+        "atoum/atoum": "^4.0",
+        "m6web/php-cs-fixer-config": "^2.0"
     },
     "autoload": {
         "psr-0": { "": "src/" }

--- a/src/M6Web/Bundle/ElasticsearchBundle/DataCollector/ElasticsearchDataCollector.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/DataCollector/ElasticsearchDataCollector.php
@@ -48,27 +48,17 @@ class ElasticsearchDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'elasticsearch';
     }
 
-    /**
-     * Get queries
-     *
-     * @return array
-     */
-    public function getQueries()
+    public function getQueries(): array
     {
         return $this->data['queries'];
     }
 
-    /**
-     * Get total execution time
-     *
-     * @return float
-     */
-    public function getTotalExecutionTime()
+    public function getTotalExecutionTime(): float
     {
         return $this->data['total_execution_time'];
     }

--- a/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/Configuration.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/Configuration.php
@@ -17,7 +17,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('m6web_elasticsearch');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/M6WebElasticsearchExtension.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/M6WebElasticsearchExtension.php
@@ -98,12 +98,8 @@ class M6WebElasticsearchExtension extends Extension
 
     /**
      * Create request handler
-     *
-     * @param string $definitionId
-     *
-     * @return string
      */
-    protected function createHandler(ContainerBuilder $container, array $config, $definitionId)
+    protected function createHandler(ContainerBuilder $container, array $config, string $definitionId): string
     {
         // cURL handler
         $singleHandler = (new Definition('GuzzleHttp\Ring\Client\CurlHandler'))
@@ -136,11 +132,7 @@ class M6WebElasticsearchExtension extends Extension
         return $eventHandlerId;
     }
 
-    /**
-     * @param string $className
-     * @param string $method
-     */
-    private function setFactoryToDefinition($className, $method, Definition $definition)
+    private function setFactoryToDefinition(string $className, string $method, Definition $definition)
     {
         $definition
             ->setFactory([$className, $method]);

--- a/src/M6Web/Bundle/ElasticsearchBundle/Elasticsearch/ConnectionPool/StaticAliveNoPingConnectionPool.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Elasticsearch/ConnectionPool/StaticAliveNoPingConnectionPool.php
@@ -17,40 +17,29 @@ use Elasticsearch\Connections\ConnectionInterface;
  */
 class StaticAliveNoPingConnectionPool extends StaticNoPingConnectionPool
 {
-    /** @var int */
-    private $pingTimeout = 60;
-
-    /** @var int */
-    private $maxPingTimeout = 3600;
+    private int $pingTimeout = 60;
+    private int $maxPingTimeout = 3600;
 
     /**
      * > Allow to customize the ping time out.
-     *
-     * @param int $pingTimeout
      */
-    public function setPingTimeout($pingTimeout)
+    public function setPingTimeout(int $pingTimeout)
     {
         $this->pingTimeout = $pingTimeout;
     }
 
     /**
      * > Allow to customize the ping max time out.
-     *
-     * @param int $maxPingTimeout
      */
-    public function setMaxPingTimeout($maxPingTimeout)
+    public function setMaxPingTimeout(int $maxPingTimeout)
     {
         $this->maxPingTimeout = $maxPingTimeout;
     }
 
     /**
-     * @param bool $force
-     *
-     * @return Connection
-     *
-     * @throws \Elasticsearch\Common\Exceptions\NoNodesAvailableException
+     * @throws NoNodesAvailableException
      */
-    public function nextConnection($force = false): ConnectionInterface
+    public function nextConnection(bool $force = false): ConnectionInterface
     {
         // > Replace $this->connections by $connections in order to modify the list later.
         $connections = $this->connections;
@@ -80,10 +69,8 @@ class StaticAliveNoPingConnectionPool extends StaticNoPingConnectionPool
 
     /**
      * > Same as parent private method.
-     *
-     * @return bool
      */
-    protected function readyToRevive(Connection $connection)
+    protected function readyToRevive(Connection $connection): bool
     {
         $timeout = min(
             $this->pingTimeout * pow(2, $connection->getPingFailures()),

--- a/src/M6Web/Bundle/ElasticsearchBundle/EventDispatcher/ElasticsearchEvent.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/EventDispatcher/ElasticsearchEvent.php
@@ -6,201 +6,118 @@ namespace M6Web\Bundle\ElasticsearchBundle\EventDispatcher;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
-/**
- * Class ElasticsearchEvent
- */
 class ElasticsearchEvent extends Event
 {
-    /** @var float duration of the Elasticsearch request in milliseconds */
-    private $duration;
+    /** duration of the Elasticsearch request in milliseconds */
+    private ?float $duration = null;
 
-    /** @var string HTTP method */
-    private $method;
+    /** HTTP method */
+    private ?string $method = null;
 
-    /** @var string Elasticsearch URI */
-    private $uri;
+    /** Elasticsearch URI */
+    private ?string $uri = null;
 
-    /** @var int HTTP status code */
-    private $statusCode;
+    /**  HTTP status code */
+    private ?int $statusCode = null;
 
-    /**
-     * Time in milliseconds for Elasticsearch to execute the search
-     *
-     * @var int
-     */
-    private $took;
+    /** Time in milliseconds for Elasticsearch to execute the search */
+    private ?int $took = null;
+    private array $headers = [];
 
-    /** @var array */
-    private $headers;
+    /** Body of the ES request */
+    private string $body = '';
+    private string $error = '';
 
-    /**
-     * Body of the ES request
-     *
-     * @var string
-     */
-    private $body;
-
-    /** @var string */
-    private $error;
-
-    /**
-     * @return float
-     */
-    public function getDuration()
+    public function getDuration(): ?float
     {
         return $this->duration;
     }
 
-    /**
-     * @param float $duration
-     *
-     * @return $this
-     */
-    public function setDuration($duration)
+    public function setDuration(float $duration): self
     {
         $this->duration = $duration;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+    public function getMethod(): ?string
     {
         return $this->method;
     }
 
-    /**
-     * @param string $method
-     *
-     * @return $this
-     */
-    public function setMethod($method)
+    public function setMethod(?string $method): self
     {
         $this->method = $method;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getUri()
+    public function getUri(): ?string
     {
         return $this->uri;
     }
 
-    /**
-     * @param string $uri
-     *
-     * @return $this
-     */
-    public function setUri($uri)
+    public function setUri(?string $uri): self
     {
         $this->uri = $uri;
 
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getStatusCode()
+    public function getStatusCode(): ?int
     {
         return $this->statusCode;
     }
 
-    /**
-     * @param int $statusCode
-     *
-     * @return $this
-     */
-    public function setStatusCode($statusCode)
+    public function setStatusCode(?int $statusCode): self
     {
         $this->statusCode = $statusCode;
 
         return $this;
     }
 
-    /**
-     * Get took
-     *
-     * @return int
-     */
-    public function getTook()
+    public function getTook(): ?int
     {
         return $this->took;
     }
 
-    /**
-     * Set took
-     *
-     * @param int $took
-     *
-     * @return $this
-     */
-    public function setTook($took)
+    public function setTook(?int $took): self
     {
         $this->took = $took;
 
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
 
-    /**
-     * @param array $headers
-     *
-     * @return $this
-     */
-    public function setHeaders($headers)
+    public function setHeaders(array $headers): self
     {
         $this->headers = $headers;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getBody()
+    public function getBody(): string
     {
         return $this->body;
     }
 
-    /**
-     * @param string $body
-     *
-     * @return $this
-     */
-    public function setBody($body)
+    public function setBody(string $body): self
     {
         $this->body = $body;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getError()
+    public function getError(): string
     {
         return $this->error;
     }
 
-    /**
-     * @param string $error
-     *
-     * @return $this
-     */
-    public function setError($error)
+    public function setError(string $error): self
     {
         $this->error = $error;
 

--- a/src/M6Web/Bundle/ElasticsearchBundle/Handler/EventHandler.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Handler/EventHandler.php
@@ -13,12 +13,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class EventHandler
 {
-    /**
-     * Event dispatcher
-     *
-     * @var EventDispatcherInterface
-     */
-    private $eventDispatcher;
+    private EventDispatcherInterface $eventDispatcher;
 
     /**
      * CURL handler
@@ -36,12 +31,7 @@ class EventHandler
         $this->handler = $handler;
     }
 
-    /**
-     * Invoke
-     *
-     * @return \GuzzleHttp\Ring\Future\FutureArray
-     */
-    public function __invoke(array $request)
+    public function __invoke(array $request): \GuzzleHttp\Ring\Future\FutureArray
     {
         $handler = $this->handler;
 
@@ -76,12 +66,7 @@ class EventHandler
         return Core::proxy($handler($request), $dispatchEvent);
     }
 
-    /**
-     * Extract took from response
-     *
-     * @return int|null
-     */
-    protected function extractTookFromResponse(array $response)
+    protected function extractTookFromResponse(array $response): ?int
     {
         if (is_null($response['body'])) {
             return null;

--- a/src/M6Web/Bundle/ElasticsearchBundle/Handler/HeadersHandler.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Handler/HeadersHandler.php
@@ -5,19 +5,11 @@ declare(strict_types=1);
 namespace M6Web\Bundle\ElasticsearchBundle\Handler;
 
 use GuzzleHttp\Ring\Core;
-use GuzzleHttp\Ring\Future\FutureInterface;
 
-/**
- * HeadersHandler
- */
 class HeadersHandler
 {
-    /**
-     * Headers
-     *
-     * @var array
-     */
-    private $headers = [];
+    /** Headers */
+    private array $headers = [];
 
     /**
      * Request handler
@@ -34,26 +26,13 @@ class HeadersHandler
         $this->handler = $handler;
     }
 
-    /**
-     * Set header
-     *
-     * @param string $key
-     * @param string $value
-     *
-     * @return $this
-     */
-    public function setHeader($key, $value)
+    public function setHeader(string $key, $value): self
     {
         $this->headers[$key] = $value;
 
         return $this;
     }
 
-    /**
-     * Invoke
-     *
-     * @return FutureInterface
-     */
     public function __invoke(array $request)
     {
         // By default, host is stored in headers and final url is forged later.

--- a/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/DependencyInjection/M6WebElasticsearchExtension.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/DependencyInjection/M6WebElasticsearchExtension.php
@@ -181,11 +181,9 @@ class M6WebElasticsearchExtension extends test
     /**
      * Check if the client is correctly instanciated
      *
-     * @param string $clientName
-     *
      * @return M6WebElasticsearchExtension $this
      */
-    protected function clientIsCorrectlyInstanciated(ContainerInterface $container, $clientName)
+    protected function clientIsCorrectlyInstanciated(ContainerInterface $container, string $clientName)
     {
         $this
             ->object($container->get('m6web_elasticsearch.client.'.$clientName))

--- a/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Elasticsearch/ConnectionMocker.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Elasticsearch/ConnectionMocker.php
@@ -12,11 +12,9 @@ use Elasticsearch\Connections\Connection;
 trait ConnectionMocker
 {
     /**
-     * @param int $numberOfConnections
-     *
      * @return Connection[]
      */
-    protected function getConnectionMocks($numberOfConnections = 1)
+    protected function getConnectionMocks(int $numberOfConnections = 1): array
     {
         return array_map([$this, 'getConnectionMock'], array_fill(0, $numberOfConnections, []));
     }

--- a/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Elasticsearch/ConnectionPool/StaticAliveNoPingConnectionPool.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Elasticsearch/ConnectionPool/StaticAliveNoPingConnectionPool.php
@@ -29,7 +29,7 @@ class StaticAliveNoPingConnectionPool extends test
 
             // Test returned class is a connection.
             ->then
-                ->object($firstConnectionReturned = $this->testedInstance->nextConnection($connections))
+                ->object($firstConnectionReturned = $this->testedInstance->nextConnection())
                     ->isIdenticalTo($first);
     }
 
@@ -44,7 +44,7 @@ class StaticAliveNoPingConnectionPool extends test
 
             // Test returned class is a connection.
             ->then
-                ->object($firstConnectionReturned = $this->testedInstance->nextConnection($connections))
+                ->object($firstConnectionReturned = $this->testedInstance->nextConnection())
                     ->isIdenticalTo($second);
     }
 
@@ -60,8 +60,8 @@ class StaticAliveNoPingConnectionPool extends test
             // Test returned class is a connection.
             ->then
                 ->exception(
-                    function () use ($connections) {
-                        $this->testedInstance->nextConnection($connections);
+                    function () {
+                        $this->testedInstance->nextConnection();
                     }
                 )
                     ->isInstanceOf(NoNodesAvailableException::class);

--- a/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Handler/EventHandler.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Handler/EventHandler.php
@@ -52,12 +52,7 @@ class EventHandler extends atoum
             ->mock($eventDispatcher)->call('dispatch')->never();
     }
 
-    /**
-     * testDispatch data provider
-     *
-     * @return array
-     */
-    protected function testDispatchDataProvider()
+    protected function testDispatchDataProvider(): array
     {
         return [
             [

--- a/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Handler/HeadersHandler.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/Tests/Units/Handler/HeadersHandler.php
@@ -44,12 +44,7 @@ class HeadersHandler extends atoum
         return $requestHandler;
     }
 
-    /**
-     * testInvoke data provider
-     *
-     * @return array
-     */
-    protected function testInvokeDataProvider()
+    protected function testInvokeDataProvider(): array
     {
         return [
             [


### PR DESCRIPTION
I found an issue when elasticsearch server response is null. The `ElasticsearchDataCollector` can't apply json_decode on a null value anymore due to the `strict_types=1` policy.

I did a check and added types everywhere it was possible. 
